### PR TITLE
feat: remove execa, setup actions to publish to beta and main

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -3,7 +3,7 @@ name: Publish to npm
 on:
   push:
     branches:
-      - dev
+      - 'dev'
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -11,9 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - name: use node.js
         uses: actions/setup-node@v4
         with:
+          node-version: 20
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
       - name: install dependencies

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,24 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
+      - name: use node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+      - name: install dependencies
+        run: pnpm install
+      - name: build and publish
+        run: pnpm pub:beta
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: install pnpm
+        uses: pnpm/action-setup@v4
+      - name: use node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+      - name: install dependencies
+        run: pnpm install
+      - name: build and publish
+        run: pnpm pub
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - name: use node.js
         uses: actions/setup-node@v4
         with:
+          node-version: 20
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
       - name: install dependencies

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     href="https://github.com/orgs/gdsc-nits-org/repositories?q=template%3Atrue+archived%3Afalse"
     >GDSC NITS project templates</a
   >
-  by running <code>npx codekon</code>
+  by running <code>pnpx codekon</code>
 </p>
 
 <div align="center">
@@ -48,9 +48,13 @@
 
 - To use `codekon` interactively:
 
+Using npm:
+
 ```bash
 npx codekon
 ```
+
+Using pnpm:
 
 ```bash
 pnpx codekon
@@ -69,10 +73,6 @@ pnpx codekon [projectName] [templateName]
 ```
 
 For example:
-
-```bash
-npx codekon my-app react-js-app
-```
 
 ```bash
 pnpx codekon my-app react-js-app
@@ -94,7 +94,7 @@ pnpx codekon my-app react-js-app
 - [x] ~~Test `pnpm create codekon`.~~ My bad. For this to work, the package name should have been `create-codekon`.
 - [ ] Add screenshots and video.
 - [x] Fix `pnpm dlx codekon`.
-- [ ] Remove `execa` and test with `child-process`.
+- [x] Remove `execa` and test with `child-process`. Reduced install size by 55%. Brought node support to `>=18` from `>= 20.5.0`.
 
 [packagephobia-image]: https://packagephobia.com/badge?p=codekon
 [packagephobia-url]: https://packagephobia.com/result?p=codekon

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@
 </p>
 
 <div align="center">
-  [![install size][packagephobia-image]][packagephobia-link][![NPM version][npm-image]][npm-url]
+
+  [![install size][packagephobia-image]][packagephobia-url] [![NPM version][npm-image]][npm-url]
+
 </div>
 
 ## About
@@ -92,6 +94,7 @@ pnpx codekon my-app react-js-app
 - [x] ~~Test `pnpm create codekon`.~~ My bad. For this to work, the package name should have been `create-codekon`.
 - [ ] Add screenshots and video.
 - [x] Fix `pnpm dlx codekon`.
+- [ ] Remove `execa` and test with `child-process`.
 
 [packagephobia-image]: https://packagephobia.com/badge?p=codekon
 [packagephobia-url]: https://packagephobia.com/result?p=codekon

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
   by running <code>npx codekon</code>
 </p>
 
+<div align="center">
+  [![install size][packagephobia-image]][packagephobia-link][![NPM version][npm-image]][npm-url]
+</div>
+
 ## About
 
 [GDSC NITS](https://gdscnits.in) has a set of templates to streamline the development of web based projects by having **opiniated** configs and settings. The various templates available are -
@@ -88,3 +92,8 @@ pnpx codekon my-app react-js-app
 - [x] ~~Test `pnpm create codekon`.~~ My bad. For this to work, the package name should have been `create-codekon`.
 - [ ] Add screenshots and video.
 - [x] Fix `pnpm dlx codekon`.
+
+[packagephobia-image]: https://packagephobia.com/badge?p=codekon
+[packagephobia-url]: https://packagephobia.com/result?p=codekon
+[npm-url]: https://www.npmjs.com/package/codekon
+[npm-image]: https://img.shields.io/npm/v/codekon?color=0b7285&logoColor=0b7285

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,13 +9,16 @@ export default [
   ...tseslint.configs.recommended,
   {
     plugins: {
-      "import": pluginImport,
+      import: pluginImport,
     },
   },
   {
     rules: {
-      "import/order": ["error", {"alphabetize": {"order": "asc", "caseInsensitive": true}}],
+      "import/order": [
+        "error",
+        { alphabetize: { order: "asc", caseInsensitive: true } },
+      ],
       // "import/no-unused-modules": ["error", {"unusedExports": true}]
-    }
-  }
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekon",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Entirety of GDSC NITS project templates at your fingertips",
   "type": "module",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "pub:beta": "pnpm build && npm publish --tag beta",
     "pub": "pnpm build && npm publish"
   },
-  "keywords": [],
+  "keywords": ["gdsc", "reactjs", "nodejs", "typescript", "template", "cli", "codekon", "express", "mongodb", "postgresql"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/gdsc-nits-org/codekon.git"

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
     "Adhiraj Dutta <bytehead.dev@gmail.com> (https://adhiraj.me)"
   ],
   "license": "GPL-3.0",
+  "engines": {
+    "node": ">= 18"
+  },
   "dependencies": {
     "commander": "^12.1.0",
-    "execa": "^9.2.0",
     "kolorist": "^1.8.0",
     "ora": "^8.0.1",
     "prompts": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekon",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Entirety of GDSC NITS project templates at your fingertips",
   "type": "module",
   "main": "dist/src/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   commander:
     specifier: ^12.1.0
     version: 12.1.0
-  execa:
-    specifier: ^9.2.0
-    version: 9.2.0
   kolorist:
     specifier: ^1.8.0
     version: 1.8.0
@@ -760,18 +757,9 @@ packages:
       fastq: 1.17.1
     dev: true
 
-  /@sec-ant/readable-stream@0.4.1:
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-    dev: false
-
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
-
-  /@sindresorhus/merge-streams@4.0.0:
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
-    engines: {node: '>=18'}
-    dev: false
 
   /@sinonjs/commons@3.0.1:
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
@@ -1448,6 +1436,7 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+    dev: true
 
   /data-view-buffer@1.0.1:
     resolution: {integrity: sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==}
@@ -1900,24 +1889,6 @@ packages:
       strip-final-newline: 2.0.0
     dev: true
 
-  /execa@9.2.0:
-    resolution: {integrity: sha512-vpOyYg7UAVKLAWWtRS2gAdgkT7oJbCn0me3gmUmxZih4kd3MF/oo8kNTBTIbkO3yuuF5uB4ZCZfn8BOolITYhg==}
-    engines: {node: ^18.19.0 || >=20.5.0}
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.3
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 7.0.0
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 5.3.0
-      pretty-ms: 9.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.0.2
-    dev: false
-
   /exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
@@ -1968,13 +1939,6 @@ packages:
     dependencies:
       bser: 2.1.1
     dev: true
-
-  /figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
-    dependencies:
-      is-unicode-supported: 2.0.0
-    dev: false
 
   /file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2089,14 +2053,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
-
-  /get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
-    dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
-    dev: false
 
   /get-symbol-description@1.0.2:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
@@ -2234,11 +2190,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
     dev: true
-
-  /human-signals@7.0.0:
-    resolution: {integrity: sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==}
-    engines: {node: '>=18.18.0'}
-    dev: false
 
   /husky@9.0.11:
     resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
@@ -2394,11 +2345,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
-    dev: false
-
   /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
@@ -2418,11 +2364,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
     dev: true
-
-  /is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
-    dev: false
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -2467,6 +2408,7 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    dev: true
 
   /istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3215,13 +3157,6 @@ packages:
       path-key: 3.1.1
     dev: true
 
-  /npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      path-key: 4.0.0
-    dev: false
-
   /object-inspect@1.13.1:
     resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
     dev: true
@@ -3358,11 +3293,6 @@ packages:
       lines-and-columns: 1.2.4
     dev: true
 
-  /parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
-    dev: false
-
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3376,11 +3306,7 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  /path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-    dev: false
+    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -3436,13 +3362,6 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.3.1
     dev: true
-
-  /pretty-ms@9.0.0:
-    resolution: {integrity: sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==}
-    engines: {node: '>=18'}
-    dependencies:
-      parse-ms: 4.0.0
-    dev: false
 
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -3601,10 +3520,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
+    dev: true
 
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+    dev: true
 
   /side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
@@ -3618,11 +3539,6 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  /signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-    dev: false
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -3741,11 +3657,6 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
-
-  /strip-final-newline@4.0.0:
-    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
-    engines: {node: '>=18'}
-    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -3991,6 +3902,7 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
 
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -4053,8 +3965,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-  /yoctocolors@2.0.2:
-    resolution: {integrity: sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==}
-    engines: {node: '>=18'}
-    dev: false

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,6 @@
-import { execa } from "execa";
+import { exec, execSync } from "node:child_process";
+import util from "node:util";
+// import { execa } from "execa";
 import ora from "ora";
 
 /**
@@ -8,7 +10,8 @@ import ora from "ora";
  */
 export const isGitInstalled = (): boolean => {
   try {
-    execa("git", ["--version"], { stdio: "ignore" });
+    // execa("git", ["--version"], { stdio: "ignore" });
+    execSync("git --version");
     return true;
   } catch (error) {
     return false;
@@ -22,7 +25,8 @@ export const isGitInstalled = (): boolean => {
  */
 export const isPnpmInstalled = (): boolean => {
   try {
-    execa("pnpm", ["--version"], { stdio: "ignore" });
+    // execa("pnpm", ["--version"], { stdio: "ignore" });
+    execSync("pnpm --version");
     return true;
   } catch (error) {
     return false;
@@ -68,7 +72,9 @@ export const installCommand = async (
 ): Promise<void> => {
   const spinner = ora("Downloading template").start();
   try {
-    await execa`pnpm dlx degit ${template} ${projectName}`;
+    const execa = util.promisify(exec);
+    // await execa`pnpm dlx degit ${template} ${projectName}`;
+    await execa(`pnpm dlx degit ${template} ${projectName}`);
     spinner.succeed("Template downloaded successfully");
   } catch (error) {
     spinner.fail("Failed to download template");


### PR DESCRIPTION
- `execa` was increasing install size by ~ 400 kb. also needed `node >= 20.5.0`. 
- switched to `node:child-process`, reducing install size and decreasing `node` ver to `>= 18`
- `beta.yml` publishes a `beta` version on each push to `dev` branch.
- `build.yml` publishes a new version on each push to `main` branch.
- set npm package tags.